### PR TITLE
Docs: Add Mac universal binary build troubleshooting guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,4 +64,36 @@ When submitting a pull request, please follow these guidelines:
 - Run `cargo test` for Rust code
 - Test the application manually before submitting
 
+## Build Issues and Solutions
+
+### macOS Universal Binary Build
+
+When contributing changes that affect the build process, especially for macOS universal binaries, be aware of this common issue:
+
+**Problem**: `bun run tauri build --target universal-apple-darwin` fails with:
+```
+failed to bundle project: Failed to copy external binaries: resource path 'binaries/claude-code-universal-apple-darwin' doesn't exist
+```
+
+**Solution**: 
+1. Build macOS binaries first: `bun run build:executables:macos`
+2. Create universal binary manually: `lipo -create -output src-tauri/binaries/claude-code-universal-apple-darwin src-tauri/binaries/claude-code-x86_64-apple-darwin src-tauri/binaries/claude-code-aarch64-apple-darwin`
+3. Run Tauri build: `bun run tauri build --target universal-apple-darwin`
+
+### Testing Your Build
+
+Before submitting a PR that affects the build process:
+
+1. **Test on your target platform**: Build and run the application
+2. **Verify binary architecture** (macOS): `lipo -info src-tauri/binaries/claude-code-universal-apple-darwin`
+3. **Check final artifacts**: Ensure `.app` and `.dmg` files are created correctly
+4. **Test the built application**: Launch the built app and verify core functionality
+
+### Known Build Dependencies
+
+Contributors should ensure these are available:
+- **macOS**: Xcode Command Line Tools, `lipo` utility
+- **All platforms**: Claude Code CLI in PATH
+- **Development**: All prerequisites listed in README.md
+
 Please adhere to the coding conventions, maintain clear documentation, and provide thorough testing for your contributions. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,24 +68,18 @@ When submitting a pull request, please follow these guidelines:
 
 ### macOS Universal Binary Build
 
-When contributing changes that affect the build process, especially for macOS universal binaries, be aware of this common issue:
+When contributing changes that affect the build process, especially for macOS universal binaries, be aware of a common build issue where the universal binary creation may fail.
 
-**Problem**: `bun run tauri build --target universal-apple-darwin` fails with:
-```
-failed to bundle project: Failed to copy external binaries: resource path 'binaries/claude-code-universal-apple-darwin' doesn't exist
-```
+**Issue**: `bun run tauri build --target universal-apple-darwin` may fail due to missing universal binary.
 
-**Solution**: 
-1. Build macOS binaries first: `bun run build:executables:macos`
-2. Create universal binary manually: `lipo -create -output src-tauri/binaries/claude-code-universal-apple-darwin src-tauri/binaries/claude-code-x86_64-apple-darwin src-tauri/binaries/claude-code-aarch64-apple-darwin`
-3. Run Tauri build: `bun run tauri build --target universal-apple-darwin`
+**Solution**: Follow the detailed [Universal Binary Creation (macOS)](README.md#universal-binary-creation-macos) guide in the README.md for the complete step-by-step solution.
 
 ### Testing Your Build
 
 Before submitting a PR that affects the build process:
 
 1. **Test on your target platform**: Build and run the application
-2. **Verify binary architecture** (macOS): `lipo -info src-tauri/binaries/claude-code-universal-apple-darwin`
+2. **Verify binary architecture** (macOS): Use `lipo -info` to check universal binary (see README.md for details)
 3. **Check final artifacts**: Ensure `.app` and `.dmg` files are created correctly
 4. **Test the built application**: Launch the built app and verify core functionality
 


### PR DESCRIPTION
## Summary
- Added comprehensive troubleshooting section for macOS universal binary build issues
- Documented the specific error and step-by-step solution for the `claude-code-universal-apple-darwin` binary creation
- Enhanced README.md with detailed Universal Binary Creation section including verification steps
- Updated CONTRIBUTING.md with build testing guidelines for contributors

## Problem Addressed
When building Mac universal binaries with `bun run tauri build --target universal-apple-darwin`, users encounter:
```
failed to bundle project: Failed to copy external binaries: resource path 'binaries/claude-code-universal-apple-darwin' doesn't exist
```

## Solution Provided
1. **Root Cause**: The build process creates separate x86_64 and ARM64 binaries but doesn't automatically combine them
2. **Manual Solution**: Use `lipo` to create the universal binary manually
3. **Step-by-step Guide**: Complete workflow from building individual binaries to final universal app

## Changes Made
### README.md
- Added "Universal Binary Creation (macOS)" section with detailed troubleshooting
- Enhanced existing build troubleshooting section with specific Mac universal binary error
- Added verification steps to confirm successful build
- Included alternative single-architecture build options

### CONTRIBUTING.md
- Added "Build Issues and Solutions" section for contributors
- Documented testing requirements for build-related PRs
- Added known build dependencies for different platforms

## Testing
- Successfully built Mac universal binary following the documented steps
- Verified binary architecture with `lipo -info`
- Confirmed final artifacts (Claudia.app and .dmg) were created correctly

## Impact
This documentation will help Mac users successfully build universal binaries without encountering the common build failure, improving the developer experience and reducing support burden.

## Test Plan
- [x] Build Mac universal binary using documented steps
- [x] Verify binary architecture with `lipo -info`
- [x] Confirm final artifacts are created (Claudia.app and .dmg)
- [x] Test the built application launches correctly